### PR TITLE
remove peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "tinycolor2": "^1.1.2"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
for our own purposes, we do not need to have react listed as a peer dependency, better to just get rid of it entirely. 